### PR TITLE
fix(protocol-http): fix timeout option on node

### DIFF
--- a/packages/plugin-protocol-http/package.json
+++ b/packages/plugin-protocol-http/package.json
@@ -31,7 +31,7 @@
     "@tinkoff/utils": "^2.0.0",
     "abort-controller": "^3.0.0",
     "form-data": "^2.5.0",
-    "node-fetch": "^2.6.0",
+    "node-fetch": "^2.6.1",
     "tslib": "^1.9.3"
   },
   "devDependencies": {

--- a/packages/plugin-protocol-http/src/http.ts
+++ b/packages/plugin-protocol-http/src/http.ts
@@ -141,8 +141,7 @@ export default ({ agent }: { agent?: { http: Agent; https: Agent } } = {}): Plug
                     abortPromise.then(abort);
                 }
 
-                if (isBrowser && timeout) {
-                    // node-fetch has timeout option, so add check only for browser
+                if (timeout) {
                     timer = setTimeout(() => {
                         abort(new Error('Request timed out'));
                     }, timeout);
@@ -152,8 +151,7 @@ export default ({ agent }: { agent?: { http: Agent; https: Agent } } = {}): Plug
                     requestAbort: abort,
                 });
             } else {
-                if (isBrowser && timeout) {
-                    // node-fetch has timeout option, so add check only for browser
+                if (timeout) {
                     timer = setTimeout(() => {
                         next({
                             status: Status.ERROR,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7584,10 +7584,15 @@ node-fetch@2.1.2:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
   integrity sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=
 
-node-fetch@^2.3.0, node-fetch@^2.5.0, node-fetch@^2.6.0:
+node-fetch@^2.3.0, node-fetch@^2.5.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
   integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
+
+node-fetch@^2.6.1:
+  version "2.6.1"
+  resolved "https://nexus-new.tcsbank.ru/repository/npm-all/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-gyp@^5.0.2:
   version "5.1.0"


### PR DESCRIPTION
Before `timeout` option was passed to `node-fetch` what actually led to increased wait time for slow request with slow response streaming. With redirects it might increase wait time to big values much higher than initial timeout.
Replace usage `node-fetch` `timeout` option with explicit call to AbortController.abort